### PR TITLE
Add Serde support behind feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,16 +3,18 @@ name = "jord"
 version = "0.15.0"
 edition = "2021"
 rust-version = "1.65"
-authors = ["Cedric Liegeois <omam.github@gmail.com>",
-          ]
+authors = ["Cedric Liegeois <omam.github@gmail.com>"]
 repository = "https://github.com/ofmooseandmen/jord-rs"
 documentation = "https://docs.rs/jord"
 keywords = ["geo", "geography", "geospatial", "n-vector"]
 description = "Geographical Position Calculations (Ellipsoidal and Spherical models)"
 license = "MIT"
 readme = "README.md"
+[features]
+serde = ["dep:serde"]
 
 [dependencies]
+serde = { version = "1", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -2,7 +2,7 @@ use crate::{impl_measurement, Measurement};
 use std::f64::consts::PI;
 
 #[derive(PartialEq, PartialOrd, Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // codecov:ignore:this
 /// A one-dimensional angle.
 ///
 /// It primarely exists to unambigously represent an angle as opposed to a bare

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -2,6 +2,7 @@ use crate::{impl_measurement, Measurement};
 use std::f64::consts::PI;
 
 #[derive(PartialEq, PartialOrd, Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// A one-dimensional angle.
 ///
 /// It primarely exists to unambigously represent an angle as opposed to a bare

--- a/src/ellipsoidal/ellipsoid.rs
+++ b/src/ellipsoidal/ellipsoid.rs
@@ -4,6 +4,7 @@ use crate::{
 
 /// An ellipsoid.
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Ellipsoid {
     equatorial_radius: Length,
     polar_radius: Length,

--- a/src/ellipsoidal/ellipsoid.rs
+++ b/src/ellipsoidal/ellipsoid.rs
@@ -4,7 +4,7 @@ use crate::{
 
 /// An ellipsoid.
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // codecov:ignore:this
 pub struct Ellipsoid {
     equatorial_radius: Length,
     polar_radius: Length,

--- a/src/length.rs
+++ b/src/length.rs
@@ -1,7 +1,7 @@
 use crate::{impl_measurement, Angle, Measurement};
 
 #[derive(PartialEq, PartialOrd, Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // codecov:ignore:this
 /// A length.
 ///
 /// It primarely exists to unambigously represent a length as opposed to a bare

--- a/src/length.rs
+++ b/src/length.rs
@@ -1,6 +1,7 @@
 use crate::{impl_measurement, Angle, Measurement};
 
 #[derive(PartialEq, PartialOrd, Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// A length.
 ///
 /// It primarely exists to unambigously represent a length as opposed to a bare

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))]
 #![deny(
     anonymous_parameters,
-    illegal_floating_point_literal_pattern,
     late_bound_lifetime_arguments,
     path_statements,
     patterns_in_fns_without_body,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))]
-#![forbid(
+#![deny(
     anonymous_parameters,
     illegal_floating_point_literal_pattern,
     late_bound_lifetime_arguments,

--- a/src/local_frame.rs
+++ b/src/local_frame.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 enum Orientation {
     // x = north (or forward), y = east (or right), z = down.
     #[default]
@@ -21,6 +22,7 @@ enum Orientation {
 /// However, the [azimuth](crate::LocalPositionVector::azimuth) is always relative to 'north' and the elevation is always positive if above the local
 /// tangent plane and negative if below.
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LocalPositionVector {
     x: Length,
     y: Length,
@@ -185,6 +187,7 @@ impl Cartesian3DVector for LocalPositionVector {
 /// calculations are needed in a limited area, position calculations can be performed
 /// relative to this system to get approximate horizontal and vertical components
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LocalFrame<S> {
     origin: Vec3,
     dir_rm: Mat33,

--- a/src/local_frame.rs
+++ b/src/local_frame.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // codecov:ignore:this
 enum Orientation {
     // x = north (or forward), y = east (or right), z = down.
     #[default]
@@ -22,7 +22,7 @@ enum Orientation {
 /// However, the [azimuth](crate::LocalPositionVector::azimuth) is always relative to 'north' and the elevation is always positive if above the local
 /// tangent plane and negative if below.
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // codecov:ignore:this
 pub struct LocalPositionVector {
     x: Length,
     y: Length,
@@ -187,7 +187,7 @@ impl Cartesian3DVector for LocalPositionVector {
 /// calculations are needed in a limited area, position calculations can be performed
 /// relative to this system to get approximate horizontal and vertical components
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // codecov:ignore:this
 pub struct LocalFrame<S> {
     origin: Vec3,
     dir_rm: Mat33,
@@ -307,7 +307,7 @@ where
     }
 
     /// Converts the given [GeodeticPos] into a [LocalPositionVector]: the exact vector between this frame
-    /// origin and the given position. The resulting [LocalPositionVector] orientation is the one of this frame.   
+    /// origin and the given position. The resulting [LocalPositionVector] orientation is the one of this frame.
     pub fn geodetic_to_local_pos(&self, p: GeodeticPos) -> LocalPositionVector {
         let p_geocentric = self.surface.geodetic_to_geocentric(p).as_metres();
         // delta in 'Earth' frame.

--- a/src/local_frame.rs
+++ b/src/local_frame.rs
@@ -19,6 +19,7 @@ enum Orientation {
 /// The orientation of the x, y and z axis depends on the [local Cartesian coordinate frame](crate::LocalFrame):
 /// - x = north (or forward), y = east (or right), z = down: [NED](crate::LocalFrame::ned), [Body](crate::LocalFrame::body) and [Local Level](crate::LocalFrame::local_level),
 /// - x = east, y = north, z = up: [ENU](crate::LocalFrame::enu).
+///
 /// However, the [azimuth](crate::LocalPositionVector::azimuth) is always relative to 'north' and the elevation is always positive if above the local
 /// tangent plane and negative if below.
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
@@ -203,7 +204,7 @@ where
     /// East-North-Up (local level) frame. This frame is useful for many targeting and tracking applications.
     ///
     /// - Orientation: The x-axis points towards east, the y-axis points towards north (both are
-    /// horizontal), and the z-axis is pointing up.
+    ///   horizontal), and the z-axis is pointing up.
     ///
     /// See also [NED](crate::LocalFrame::ned)
     pub fn enu(origin: GeodeticPos, surface: S) -> Self {
@@ -231,7 +232,7 @@ where
     ///
     /// - The origin is directly beneath or above the vehicle (B), at Earth’s surface.
     /// - Orientation: The x-axis points towards north, the y-axis points towards east (both are
-    /// horizontal), and the z-axis is pointing down.
+    ///   horizontal), and the z-axis is pointing down.
     ///
     /// Note: When moving relative to the Earth, the frame rotates about its z-axis to allow the
     /// x-axis to always point towards north. When getting close to the poles this rotation rate
@@ -282,10 +283,10 @@ where
     ///
     /// - The origin is directly beneath or above the vehicle (B), at Earth’s surface.
     /// - Orientation: The z-axis is pointing down. Initially, the x-axis points towards north, and the
-    /// y-axis points towards east, but as the vehicle moves they are not rotating about the z-axis
-    /// (their angular velocity relative to the Earth has zero component along the z-axis).
-    /// (Note: Any initial horizontal direction of the x- and y-axes is valid for L, but if the
-    /// initial position is outside the poles, north and east are usually chosen for convenience.)
+    ///   y-axis points towards east, but as the vehicle moves they are not rotating about the z-axis
+    ///   (their angular velocity relative to the Earth has zero component along the z-axis).
+    ///   (Note: Any initial horizontal direction of the x- and y-axes is valid for L, but if the
+    ///   initial position is outside the poles, north and east are usually chosen for convenience.)
     ///
     /// Notes: The L-frame is equal to the N-frame except for the rotation about the z-axis,
     /// which is always zero for this frame (relative to Earth). Hence, at a given time, the only

--- a/src/mat33.rs
+++ b/src/mat33.rs
@@ -2,7 +2,7 @@ use crate::Vec3;
 
 /// A 3*3 matrix.
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // codecov:ignore:this
 pub struct Mat33 {
     r0: Vec3,
     r1: Vec3,

--- a/src/mat33.rs
+++ b/src/mat33.rs
@@ -2,6 +2,7 @@ use crate::Vec3;
 
 /// A 3*3 matrix.
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Mat33 {
     r0: Vec3,
     r1: Vec3,

--- a/src/positions.rs
+++ b/src/positions.rs
@@ -226,7 +226,7 @@ impl LatLong {
 /// - z-axis points to the North Pole along the body's rotation axis,
 /// - x-axis points towards the point where latitude = longitude = 0
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
-
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NVector(Vec3);
 
 impl NVector {

--- a/src/positions.rs
+++ b/src/positions.rs
@@ -51,6 +51,7 @@ pub trait Cartesian3DVector: Sized {
 
 /// A geocentric position or Earth Centred Earth Fixed (ECEF) vector.
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GeocentricPos {
     x: Length,
     y: Length,
@@ -104,6 +105,7 @@ impl Cartesian3DVector for GeocentricPos {
 
 /// A geodetic position: the horiztonal coordinates (as a [NVector]) and height above the surface.
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GeodeticPos {
     hp: NVector,
     height: Length,
@@ -130,6 +132,7 @@ impl GeodeticPos {
 
 /// An horizontal position represented by a pair of latitude-longitude.
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LatLong {
     latitude: Angle,
     longitude: Angle,
@@ -223,6 +226,7 @@ impl LatLong {
 /// - z-axis points to the North Pole along the body's rotation axis,
 /// - x-axis points towards the point where latitude = longitude = 0
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
+
 pub struct NVector(Vec3);
 
 impl NVector {

--- a/src/positions.rs
+++ b/src/positions.rs
@@ -51,7 +51,7 @@ pub trait Cartesian3DVector: Sized {
 
 /// A geocentric position or Earth Centred Earth Fixed (ECEF) vector.
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // codecov:ignore:this
 pub struct GeocentricPos {
     x: Length,
     y: Length,
@@ -105,7 +105,7 @@ impl Cartesian3DVector for GeocentricPos {
 
 /// A geodetic position: the horiztonal coordinates (as a [NVector]) and height above the surface.
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // codecov:ignore:this
 pub struct GeodeticPos {
     hp: NVector,
     height: Length,
@@ -132,7 +132,7 @@ impl GeodeticPos {
 
 /// An horizontal position represented by a pair of latitude-longitude.
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // codecov:ignore:this
 pub struct LatLong {
     latitude: Angle,
     longitude: Angle,
@@ -226,7 +226,7 @@ impl LatLong {
 /// - z-axis points to the North Pole along the body's rotation axis,
 /// - x-axis points towards the point where latitude = longitude = 0
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // codecov:ignore:this
 pub struct NVector(Vec3);
 
 impl NVector {

--- a/src/speed.rs
+++ b/src/speed.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use crate::{impl_measurement, Length, Measurement};
 
 #[derive(PartialEq, PartialOrd, Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// A speed.
 ///
 /// It primarely exists to unambigously represent a speed as opposed to a bare

--- a/src/speed.rs
+++ b/src/speed.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use crate::{impl_measurement, Length, Measurement};
 
 #[derive(PartialEq, PartialOrd, Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // codecov:ignore:this
 /// A speed.
 ///
 /// It primarely exists to unambigously represent a speed as opposed to a bare
@@ -55,7 +55,7 @@ use crate::{impl_measurement, Length, Measurement};
 ///     Length::from_nautical_miles(2.0),
 ///     (Speed::from_knots(1.0) * Duration::from_secs(7200)).round_mm()
 /// );
-///  
+///
 /// ```
 pub struct Speed {
     mps: f64,

--- a/src/spherical/cap.rs
+++ b/src/spherical/cap.rs
@@ -7,6 +7,7 @@ use super::Sphere;
 /// A [spherical cap](https://en.wikipedia.org/wiki/Spherical_cap): a portion of a sphere cut off by a plane.
 /// This struct and implementation is very much based on [S2Cap](https://github.com/google/s2geometry/blob/master/src/s2/s2cap.h).
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Cap {
     centre: NVector,
     chord_radius2: f64,

--- a/src/spherical/cap.rs
+++ b/src/spherical/cap.rs
@@ -7,7 +7,7 @@ use super::Sphere;
 /// A [spherical cap](https://en.wikipedia.org/wiki/Spherical_cap): a portion of a sphere cut off by a plane.
 /// This struct and implementation is very much based on [S2Cap](https://github.com/google/s2geometry/blob/master/src/s2/s2cap.h).
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // codecov:ignore:this
 pub struct Cap {
     centre: NVector,
     chord_radius2: f64,

--- a/src/spherical/great_circle.rs
+++ b/src/spherical/great_circle.rs
@@ -9,6 +9,7 @@ use super::base::easting;
 /// It is internally represented as its normal vector - i.e. the normal vector
 /// to the plane containing the great circle.
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GreatCircle {
     normal: Vec3,
 }

--- a/src/spherical/great_circle.rs
+++ b/src/spherical/great_circle.rs
@@ -9,7 +9,7 @@ use super::base::easting;
 /// It is internally represented as its normal vector - i.e. the normal vector
 /// to the plane containing the great circle.
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // codecov:ignore:this
 pub struct GreatCircle {
     normal: Vec3,
 }

--- a/src/spherical/minor_arc.rs
+++ b/src/spherical/minor_arc.rs
@@ -8,6 +8,7 @@ use super::base::{angle_radians_between, exact_side};
 /// Oriented minor arc of a great circle between two positions: shortest path between positions
 /// on a great circle.
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MinorArc {
     start: NVector,
     end: NVector,

--- a/src/spherical/minor_arc.rs
+++ b/src/spherical/minor_arc.rs
@@ -8,7 +8,7 @@ use super::base::{angle_radians_between, exact_side};
 /// Oriented minor arc of a great circle between two positions: shortest path between positions
 /// on a great circle.
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // codecov:ignore:this
 pub struct MinorArc {
     start: NVector,
     end: NVector,

--- a/src/spherical/rectangle.rs
+++ b/src/spherical/rectangle.rs
@@ -11,6 +11,7 @@ use super::MinorArc;
 ///
 /// This struct and implementation is very much based on [S2LatLngRect](https://github.com/google/s2geometry/blob/master/src/s2/s2latlng_rect.h).
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Rectangle {
     lat: LatitudeInterval,
     lng: LongitudeInterval,
@@ -317,6 +318,7 @@ impl Rectangle {
 
 /// latitude interval: {@link #lo} is assumed to be less than {@link #hi}, otherwise the interval is empty.
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct LatitudeInterval {
     lo: Angle,
     hi: Angle,
@@ -450,6 +452,7 @@ impl LatitudeInterval {
 }
 
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct LongitudeInterval {
     lo: Angle,
     hi: Angle,

--- a/src/spherical/rectangle.rs
+++ b/src/spherical/rectangle.rs
@@ -11,7 +11,7 @@ use super::MinorArc;
 ///
 /// This struct and implementation is very much based on [S2LatLngRect](https://github.com/google/s2geometry/blob/master/src/s2/s2latlng_rect.h).
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // codecov:ignore:this
 pub struct Rectangle {
     lat: LatitudeInterval,
     lng: LongitudeInterval,
@@ -318,7 +318,7 @@ impl Rectangle {
 
 /// latitude interval: {@link #lo} is assumed to be less than {@link #hi}, otherwise the interval is empty.
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // codecov:ignore:this
 struct LatitudeInterval {
     lo: Angle,
     hi: Angle,
@@ -452,7 +452,7 @@ impl LatitudeInterval {
 }
 
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // codecov:ignore:this
 struct LongitudeInterval {
     lo: Angle,
     hi: Angle,

--- a/src/spherical/sloop.rs
+++ b/src/spherical/sloop.rs
@@ -17,6 +17,7 @@ use super::{
 /// - [simple](crate::spherical::Loop::is_simple) - this property is not enforced at runtime, therefore operations are undefined on non-simple loops
 /// - or, [empty](crate::spherical::Loop::is_empty).
 #[derive(PartialEq, Clone, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Loop {
     /// vertices in clockwise order.
     vertices: Vec<Vertex>,
@@ -661,6 +662,7 @@ pub fn is_loop_clockwise(vs: &[NVector]) -> bool {
 }
 
 #[derive(PartialEq, Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 enum Classification {
     Convex,
     Reflex,
@@ -670,6 +672,7 @@ enum Classification {
 
 /// A vertex of a loop: position + classification.
 #[derive(PartialEq, Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct Vertex(NVector, Classification);
 
 /// if first == last, returns [first ... last - 1] otherwise returns given array.

--- a/src/spherical/sloop.rs
+++ b/src/spherical/sloop.rs
@@ -532,7 +532,7 @@ impl Loop {
     }
 
     /// Triangulates this loop using the [Ear Clipping](https://www.geometrictools.com/Documentation/TriangulationByEarClipping.pdf) method.
-    ///  
+    ///
     /// This method returns either ([loop number vertices](crate::spherical::Loop::num_vertices) - 2) triangles - as triples of [NVector]s, if
     /// the triangulation succeeds, or [empty](Vec::new) if the triangulation fails - which should only occur for [non simple](crate::spherical::Loop::is_simple) loops.
     ///

--- a/src/spherical/sloop.rs
+++ b/src/spherical/sloop.rs
@@ -17,7 +17,7 @@ use super::{
 /// - [simple](crate::spherical::Loop::is_simple) - this property is not enforced at runtime, therefore operations are undefined on non-simple loops
 /// - or, [empty](crate::spherical::Loop::is_empty).
 #[derive(PartialEq, Clone, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // codecov:ignore:this
 pub struct Loop {
     /// vertices in clockwise order.
     vertices: Vec<Vertex>,
@@ -662,7 +662,7 @@ pub fn is_loop_clockwise(vs: &[NVector]) -> bool {
 }
 
 #[derive(PartialEq, Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // codecov:ignore:this
 enum Classification {
     Convex,
     Reflex,
@@ -672,7 +672,7 @@ enum Classification {
 
 /// A vertex of a loop: position + classification.
 #[derive(PartialEq, Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // codecov:ignore:this
 struct Vertex(NVector, Classification);
 
 /// if first == last, returns [first ... last - 1] otherwise returns given array.

--- a/src/spherical/sphere.rs
+++ b/src/spherical/sphere.rs
@@ -14,6 +14,7 @@ use super::{
 ///
 /// [Sphere] implements several usefull navigation algorithms.
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Sphere {
     radius: Length,
 }

--- a/src/spherical/sphere.rs
+++ b/src/spherical/sphere.rs
@@ -14,7 +14,7 @@ use super::{
 ///
 /// [Sphere] implements several usefull navigation algorithms.
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // codecov:ignore:this
 pub struct Sphere {
     radius: Length,
 }

--- a/src/vec3.rs
+++ b/src/vec3.rs
@@ -3,7 +3,7 @@
 /// [Vec3] implements many traits, including [Add](::std::ops::Add), [Sub](::std::ops::Sub),
 /// [Mul](::std::ops::Mul) and [Div](::std::ops::Div), among others.
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // codecov:ignore:this
 pub struct Vec3 {
     x: f64,
     y: f64,

--- a/src/vec3.rs
+++ b/src/vec3.rs
@@ -3,6 +3,7 @@
 /// [Vec3] implements many traits, including [Add](::std::ops::Add), [Sub](::std::ops::Sub),
 /// [Mul](::std::ops::Mul) and [Div](::std::ops::Div), among others.
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Vec3 {
     x: f64,
     y: f64,

--- a/src/vehicle.rs
+++ b/src/vehicle.rs
@@ -2,6 +2,7 @@ use crate::{Angle, NVector, Speed};
 
 /// The state of a vehicle: its horizontal position and velocity (bearing and speed).
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Vehicle {
     position: NVector,
     bearing: Angle,

--- a/src/vehicle.rs
+++ b/src/vehicle.rs
@@ -2,7 +2,7 @@ use crate::{Angle, NVector, Speed};
 
 /// The state of a vehicle: its horizontal position and velocity (bearing and speed).
 #[derive(PartialEq, Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))] // codecov:ignore:this
 pub struct Vehicle {
     position: NVector,
     bearing: Angle,


### PR DESCRIPTION
Hello!  Thanks for putting together such a fantastic library.  I'm doing some experimental work on improved tooling for underwater cave survey, and Jord  does much of what I need other than serializing data types.  I added  serialization for each struct and enum, and the changes are behind a serde feature flag, so there are no additional dependencies unless someone enables the feature.
Additionally I did switch the crate level lint from forbid to deny. Forbid was giving a false positive for unused crates, and is being replaced anyways:
https://github.com/rust-lang/rust/issues/81670